### PR TITLE
Add API controllers, update dependencies, and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 ﻿.vs
 obj
+bin

--- a/Controllers/ActorsController.cs
+++ b/Controllers/ActorsController.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Jovian_Project_Backend.Data;
+using Jovian_Project_Backend.Models;
+
+namespace Jovian_Project_Backend.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class ActorsController : ControllerBase
+    {
+        private readonly ApplicationDbContext _context;
+
+        public ActorsController(ApplicationDbContext context)
+        {
+            _context = context;
+        }
+
+        // GET: api/Actors
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<Actor>>> GetActors()
+        {
+            return await _context.Actors.ToListAsync();
+        }
+
+        // GET: api/Actors/5
+        [HttpGet("{id}")]
+        public async Task<ActionResult<Actor>> GetActor(Guid id)
+        {
+            var actor = await _context.Actors.FindAsync(id);
+
+            if (actor == null)
+            {
+                return NotFound();
+            }
+
+            return actor;
+        }
+
+        // PUT: api/Actors/5
+        // To protect from overposting attacks, see https://go.microsoft.com/fwlink/?linkid=2123754
+        [HttpPut("{id}")]
+        public async Task<IActionResult> PutActor(Guid id, Actor actor)
+        {
+            if (id != actor.ID)
+            {
+                return BadRequest();
+            }
+
+            _context.Entry(actor).State = EntityState.Modified;
+
+            try
+            {
+                await _context.SaveChangesAsync();
+            }
+            catch (DbUpdateConcurrencyException)
+            {
+                if (!ActorExists(id))
+                {
+                    return NotFound();
+                }
+                else
+                {
+                    throw;
+                }
+            }
+
+            return NoContent();
+        }
+
+        // POST: api/Actors
+        // To protect from overposting attacks, see https://go.microsoft.com/fwlink/?linkid=2123754
+        [HttpPost]
+        public async Task<ActionResult<Actor>> PostActor(Actor actor)
+        {
+            _context.Actors.Add(actor);
+            await _context.SaveChangesAsync();
+
+            return CreatedAtAction("GetActor", new { id = actor.ID }, actor);
+        }
+
+        // DELETE: api/Actors/5
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> DeleteActor(Guid id)
+        {
+            var actor = await _context.Actors.FindAsync(id);
+            if (actor == null)
+            {
+                return NotFound();
+            }
+
+            _context.Actors.Remove(actor);
+            await _context.SaveChangesAsync();
+
+            return NoContent();
+        }
+
+        private bool ActorExists(Guid id)
+        {
+            return _context.Actors.Any(e => e.ID == id);
+        }
+    }
+}

--- a/Controllers/InfoActorsController.cs
+++ b/Controllers/InfoActorsController.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Jovian_Project_Backend.Data;
+using Jovian_Project_Backend.Models;
+
+namespace Jovian_Project_Backend.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class InfoActorsController : ControllerBase
+    {
+        private readonly ApplicationDbContext _context;
+
+        public InfoActorsController(ApplicationDbContext context)
+        {
+            _context = context;
+        }
+
+        // GET: api/InfoActors
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<InfoActor>>> GetActorsActor()
+        {
+            return await _context.ActorsActor.ToListAsync();
+        }
+
+        // GET: api/InfoActors/5
+        [HttpGet("{id}")]
+        public async Task<ActionResult<InfoActor>> GetInfoActor(Guid id)
+        {
+            var infoActor = await _context.ActorsActor.FindAsync(id);
+
+            if (infoActor == null)
+            {
+                return NotFound();
+            }
+
+            return infoActor;
+        }
+
+        // PUT: api/InfoActors/5
+        // To protect from overposting attacks, see https://go.microsoft.com/fwlink/?linkid=2123754
+        [HttpPut("{id}")]
+        public async Task<IActionResult> PutInfoActor(Guid id, InfoActor infoActor)
+        {
+            if (id != infoActor.ID)
+            {
+                return BadRequest();
+            }
+
+            _context.Entry(infoActor).State = EntityState.Modified;
+
+            try
+            {
+                await _context.SaveChangesAsync();
+            }
+            catch (DbUpdateConcurrencyException)
+            {
+                if (!InfoActorExists(id))
+                {
+                    return NotFound();
+                }
+                else
+                {
+                    throw;
+                }
+            }
+
+            return NoContent();
+        }
+
+        // POST: api/InfoActors
+        // To protect from overposting attacks, see https://go.microsoft.com/fwlink/?linkid=2123754
+        [HttpPost]
+        public async Task<ActionResult<InfoActor>> PostInfoActor(InfoActor infoActor)
+        {
+            _context.ActorsActor.Add(infoActor);
+            await _context.SaveChangesAsync();
+
+            return CreatedAtAction("GetInfoActor", new { id = infoActor.ID }, infoActor);
+        }
+
+        // DELETE: api/InfoActors/5
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> DeleteInfoActor(Guid id)
+        {
+            var infoActor = await _context.ActorsActor.FindAsync(id);
+            if (infoActor == null)
+            {
+                return NotFound();
+            }
+
+            _context.ActorsActor.Remove(infoActor);
+            await _context.SaveChangesAsync();
+
+            return NoContent();
+        }
+
+        private bool InfoActorExists(Guid id)
+        {
+            return _context.ActorsActor.Any(e => e.ID == id);
+        }
+    }
+}

--- a/Controllers/InfoesController.cs
+++ b/Controllers/InfoesController.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Jovian_Project_Backend.Data;
+using Jovian_Project_Backend.Models;
+
+namespace Jovian_Project_Backend.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class InfoesController : ControllerBase
+    {
+        private readonly ApplicationDbContext _context;
+
+        public InfoesController(ApplicationDbContext context)
+        {
+            _context = context;
+        }
+
+        // GET: api/Infoes
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<Info>>> GetInfo()
+        {
+            return await _context.Info.ToListAsync();
+        }
+
+        // GET: api/Infoes/5
+        [HttpGet("{id}")]
+        public async Task<ActionResult<Info>> GetInfo(Guid id)
+        {
+            var info = await _context.Info.FindAsync(id);
+
+            if (info == null)
+            {
+                return NotFound();
+            }
+
+            return info;
+        }
+
+        // PUT: api/Infoes/5
+        // To protect from overposting attacks, see https://go.microsoft.com/fwlink/?linkid=2123754
+        [HttpPut("{id}")]
+        public async Task<IActionResult> PutInfo(Guid id, Info info)
+        {
+            if (id != info.ID)
+            {
+                return BadRequest();
+            }
+
+            _context.Entry(info).State = EntityState.Modified;
+
+            try
+            {
+                await _context.SaveChangesAsync();
+            }
+            catch (DbUpdateConcurrencyException)
+            {
+                if (!InfoExists(id))
+                {
+                    return NotFound();
+                }
+                else
+                {
+                    throw;
+                }
+            }
+
+            return NoContent();
+        }
+
+        // POST: api/Infoes
+        // To protect from overposting attacks, see https://go.microsoft.com/fwlink/?linkid=2123754
+        [HttpPost]
+        public async Task<ActionResult<Info>> PostInfo(Info info)
+        {
+            _context.Info.Add(info);
+            await _context.SaveChangesAsync();
+
+            return CreatedAtAction("GetInfo", new { id = info.ID }, info);
+        }
+
+        // DELETE: api/Infoes/5
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> DeleteInfo(Guid id)
+        {
+            var info = await _context.Info.FindAsync(id);
+            if (info == null)
+            {
+                return NotFound();
+            }
+
+            _context.Info.Remove(info);
+            await _context.SaveChangesAsync();
+
+            return NoContent();
+        }
+
+        private bool InfoExists(Guid id)
+        {
+            return _context.Info.Any(e => e.ID == id);
+        }
+    }
+}

--- a/Controllers/ThreatDiagramsController.cs
+++ b/Controllers/ThreatDiagramsController.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Jovian_Project_Backend.Data;
+using Jovian_Project_Backend.Models;
+
+namespace Jovian_Project_Backend.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class ThreatDiagramsController : ControllerBase
+    {
+        private readonly ApplicationDbContext _context;
+
+        public ThreatDiagramsController(ApplicationDbContext context)
+        {
+            _context = context;
+        }
+
+        // GET: api/ThreatDiagrams
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<ThreatDiagram>>> GetThreatDiagram()
+        {
+            return await _context.ThreatDiagram.ToListAsync();
+        }
+
+        // GET: api/ThreatDiagrams/5
+        [HttpGet("{id}")]
+        public async Task<ActionResult<ThreatDiagram>> GetThreatDiagram(Guid id)
+        {
+            var threatDiagram = await _context.ThreatDiagram.FindAsync(id);
+
+            if (threatDiagram == null)
+            {
+                return NotFound();
+            }
+
+            return threatDiagram;
+        }
+
+        // PUT: api/ThreatDiagrams/5
+        // To protect from overposting attacks, see https://go.microsoft.com/fwlink/?linkid=2123754
+        [HttpPut("{id}")]
+        public async Task<IActionResult> PutThreatDiagram(Guid id, ThreatDiagram threatDiagram)
+        {
+            if (id != threatDiagram.ID)
+            {
+                return BadRequest();
+            }
+
+            _context.Entry(threatDiagram).State = EntityState.Modified;
+
+            try
+            {
+                await _context.SaveChangesAsync();
+            }
+            catch (DbUpdateConcurrencyException)
+            {
+                if (!ThreatDiagramExists(id))
+                {
+                    return NotFound();
+                }
+                else
+                {
+                    throw;
+                }
+            }
+
+            return NoContent();
+        }
+
+        // POST: api/ThreatDiagrams
+        // To protect from overposting attacks, see https://go.microsoft.com/fwlink/?linkid=2123754
+        [HttpPost]
+        public async Task<ActionResult<ThreatDiagram>> PostThreatDiagram(ThreatDiagram threatDiagram)
+        {
+            _context.ThreatDiagram.Add(threatDiagram);
+            await _context.SaveChangesAsync();
+
+            return CreatedAtAction("GetThreatDiagram", new { id = threatDiagram.ID }, threatDiagram);
+        }
+
+        // DELETE: api/ThreatDiagrams/5
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> DeleteThreatDiagram(Guid id)
+        {
+            var threatDiagram = await _context.ThreatDiagram.FindAsync(id);
+            if (threatDiagram == null)
+            {
+                return NotFound();
+            }
+
+            _context.ThreatDiagram.Remove(threatDiagram);
+            await _context.SaveChangesAsync();
+
+            return NoContent();
+        }
+
+        private bool ThreatDiagramExists(Guid id)
+        {
+            return _context.ThreatDiagram.Any(e => e.ID == id);
+        }
+    }
+}

--- a/Controllers/ThreatsController.cs
+++ b/Controllers/ThreatsController.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Jovian_Project_Backend.Data;
+using Jovian_Project_Backend.Models;
+
+namespace Jovian_Project_Backend.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class ThreatsController : ControllerBase
+    {
+        private readonly ApplicationDbContext _context;
+
+        public ThreatsController(ApplicationDbContext context)
+        {
+            _context = context;
+        }
+
+        // GET: api/Threats
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<Threat>>> GetThreat()
+        {
+            return await _context.Threat.ToListAsync();
+        }
+
+        // GET: api/Threats/5
+        [HttpGet("{id}")]
+        public async Task<ActionResult<Threat>> GetThreat(Guid id)
+        {
+            var threat = await _context.Threat.FindAsync(id);
+
+            if (threat == null)
+            {
+                return NotFound();
+            }
+
+            return threat;
+        }
+
+        // PUT: api/Threats/5
+        // To protect from overposting attacks, see https://go.microsoft.com/fwlink/?linkid=2123754
+        [HttpPut("{id}")]
+        public async Task<IActionResult> PutThreat(Guid id, Threat threat)
+        {
+            if (id != threat.ID)
+            {
+                return BadRequest();
+            }
+
+            _context.Entry(threat).State = EntityState.Modified;
+
+            try
+            {
+                await _context.SaveChangesAsync();
+            }
+            catch (DbUpdateConcurrencyException)
+            {
+                if (!ThreatExists(id))
+                {
+                    return NotFound();
+                }
+                else
+                {
+                    throw;
+                }
+            }
+
+            return NoContent();
+        }
+
+        // POST: api/Threats
+        // To protect from overposting attacks, see https://go.microsoft.com/fwlink/?linkid=2123754
+        [HttpPost]
+        public async Task<ActionResult<Threat>> PostThreat(Threat threat)
+        {
+            _context.Threat.Add(threat);
+            await _context.SaveChangesAsync();
+
+            return CreatedAtAction("GetThreat", new { id = threat.ID }, threat);
+        }
+
+        // DELETE: api/Threats/5
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> DeleteThreat(Guid id)
+        {
+            var threat = await _context.Threat.FindAsync(id);
+            if (threat == null)
+            {
+                return NotFound();
+            }
+
+            _context.Threat.Remove(threat);
+            await _context.SaveChangesAsync();
+
+            return NoContent();
+        }
+
+        private bool ThreatExists(Guid id)
+        {
+            return _context.Threat.Any(e => e.ID == id);
+        }
+    }
+}

--- a/Jovian-Project-Backend.csproj
+++ b/Jovian-Project-Backend.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.11" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.16" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" Version="8.0.16" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.16">
@@ -22,7 +23,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.7" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
   </ItemGroup>
 
 

--- a/Jovian-Project-Backend.csproj.user
+++ b/Jovian-Project-Backend.csproj.user
@@ -2,6 +2,15 @@
 <Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ActiveDebugProfile>http</ActiveDebugProfile>
+    <Controller_SelectedScaffolderID>ApiControllerWithContextScaffolder</Controller_SelectedScaffolderID>
+    <Controller_SelectedScaffolderCategoryPath>root/Common/Api</Controller_SelectedScaffolderCategoryPath>
+    <WebStackScaffolding_ControllerDialogWidth>650</WebStackScaffolding_ControllerDialogWidth>
+    <WebStackScaffolding_IsLayoutPageSelected>True</WebStackScaffolding_IsLayoutPageSelected>
+    <WebStackScaffolding_IsPartialViewSelected>False</WebStackScaffolding_IsPartialViewSelected>
+    <WebStackScaffolding_IsReferencingScriptLibrariesSelected>True</WebStackScaffolding_IsReferencingScriptLibrariesSelected>
+    <WebStackScaffolding_LayoutPageFile />
+    <WebStackScaffolding_DbContextTypeFullName>Jovian_Project_Backend.Data.ApplicationDbContext</WebStackScaffolding_DbContextTypeFullName>
+    <WebStackScaffolding_IsAsyncSelected>False</WebStackScaffolding_IsAsyncSelected>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DebuggerFlavor>ProjectDebugger</DebuggerFlavor>

--- a/Program.cs
+++ b/Program.cs
@@ -1,3 +1,5 @@
+using Jovian_Project_Backend.Data;
+using Microsoft.EntityFrameworkCore;
 
 namespace Jovian_Project_Backend
 {
@@ -10,6 +12,13 @@ namespace Jovian_Project_Backend
             // Add services to the container.
 
             builder.Services.AddControllers();
+
+            builder.Services.AddDbContext<ApplicationDbContext>(options =>
+            {
+                options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection"));
+            });
+
+
             // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
             builder.Services.AddEndpointsApiExplorer();
             builder.Services.AddSwaggerGen();


### PR DESCRIPTION
Introduced new API controllers for CRUD operations on entities: `Actor`, `InfoActor`, `Info`, `ThreatDiagram`, and `Threat`. These controllers were scaffolded and integrated with the `ApplicationDbContext`.

Updated project dependencies:
- Added `Microsoft.AspNetCore.OpenApi` (v8.0.11) for OpenAPI/Swagger.
- Updated `Swashbuckle.AspNetCore` to v6.9.0.
- Added `Microsoft.VisualStudio.Web.CodeGeneration.Design` (v8.0.7).

Configured SQL Server in `Program.cs` with `DefaultConnection`.

Updated `.gitignore` to exclude build-related directories.