### PR TITLE
Support multiple DB providers & improve ApplicationDbContext

### DIFF
--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -5,14 +5,36 @@ namespace Jovian_Project_Backend.Data
 {
     public class ApplicationDbContext : DbContext
     {
+        public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : base(options) { }
         public DbSet<Actor> Actors { get; set; }
         public DbSet<Info> Info { get; set; }
         public DbSet<InfoActor> ActorsActor { get; set; }
         public DbSet<Threat> Threat { get; set; }
         public DbSet<ThreatDiagram> ThreatDiagram { get; set; }
 
-        //hello this is just to check git
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<InfoActor>()
+            .HasOne(ia => ia.Info)
+            .WithMany(i => i.InfoActors)
+            .HasForeignKey(ia => ia.InfoID);
 
-        public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : base(options) { }
+            modelBuilder.Entity<InfoActor>()
+            .HasOne(ia => ia.Actor)
+            .WithMany(a => a.InfoActors)
+            .HasForeignKey(ia => ia.ActorID);
+
+            modelBuilder.Entity<Threat>()
+            .HasOne(t => t.Info)
+            .WithMany(i => i.Threats)
+            .HasForeignKey(t => t.InfoID);
+
+            modelBuilder.Entity<ThreatDiagram>()
+            .HasOne(td => td.Info)
+            .WithMany(i => i.ThreatDiagrams)
+            .HasForeignKey(td => td.InfoID);
+        }
+
+
     }
 }

--- a/Jovian-Project-Backend.csproj
+++ b/Jovian-Project-Backend.csproj
@@ -24,6 +24,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.7" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
   </ItemGroup>
 

--- a/Program.cs
+++ b/Program.cs
@@ -1,3 +1,4 @@
+using System;
 using Jovian_Project_Backend.Data;
 using Microsoft.EntityFrameworkCore;
 
@@ -11,13 +12,22 @@ namespace Jovian_Project_Backend
 
             // Add services to the container.
 
-            builder.Services.AddControllers();
+            var dbProvider = builder.Configuration["DatabaseProvider"];
 
-            builder.Services.AddDbContext<ApplicationDbContext>(options =>
+            if (dbProvider == "MSSQL")
             {
-                options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection"));
-            });
+                builder.Services.AddDbContext<ApplicationDbContext>(options =>
+                options.UseSqlServer(builder.Configuration.GetConnectionString("MSSQL")));
+            }
+            else if (dbProvider == "MySQL")
+            {
+                builder.Services.AddDbContext<ApplicationDbContext>(options =>
+                options.UseMySql(builder.Configuration.GetConnectionString("MySQL"),
+                ServerVersion.AutoDetect(builder.Configuration.GetConnectionString("MySQL"))));
+            }
 
+
+            builder.Services.AddControllers();
 
             // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
             builder.Services.AddEndpointsApiExplorer();

--- a/appsettings.json
+++ b/appsettings.json
@@ -6,8 +6,11 @@
         }
     },
     "AllowedHosts": "*",
-    "ConnectionStrings": {
-        "DefaultConnection": "Server=(localDB)\\mssqllocaldb;database = zensarDB1;trusted_connection = True;multipleactiveresultsets = True;"
-    }
+    "DatabaseProvider": "MySQL",
 
+    "ConnectionStrings": {
+        "MSSQL": "Server=(localDB)\\mssqllocaldb;database = zensarDB1;trusted_connection = True;multipleactiveresultsets = True",
+        "MySQL": "server=localhost; database=temp; user=root; password=root;"
+    }
+   
 }


### PR DESCRIPTION
Added support for MSSQL and MySQL in `Program.cs` by dynamically configuring the database provider based on the `DatabaseProvider` key in `appsettings.json`. Updated `appsettings.json` with new connection strings and configuration. Added `Pomelo.EntityFrameworkCore.MySql` package for MySQL support.

Enhanced `ApplicationDbContext` with Fluent API configurations for entity relationships and improved organization by moving the constructor to the top. Removed placeholder comment for cleanliness.

Performed general code cleanup, added necessary `using` directives, and improved dependency injection structure in `Program.cs`.