### PR TITLE
Migrate database schema to MySQL and update models

### DIFF
--- a/Migrations/20250523092951_1 Actor and InfoActor table name fixed 2 Info actor column name fixed.Designer.cs
+++ b/Migrations/20250523092951_1 Actor and InfoActor table name fixed 2 Info actor column name fixed.Designer.cs
@@ -4,6 +4,7 @@ using Jovian_Project_Backend.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Jovian_Project_Backend.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250523092951_1 Actor and InfoActor table name fixed 2 Info actor column name fixed")]
+    partial class _1ActorandInfoActortablenamefixed2Infoactorcolumnnamefixed
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20250523092951_1 Actor and InfoActor table name fixed 2 Info actor column name fixed.cs
+++ b/Migrations/20250523092951_1 Actor and InfoActor table name fixed 2 Info actor column name fixed.cs
@@ -1,0 +1,1024 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Jovian_Project_Backend.Migrations
+{
+    /// <inheritdoc />
+    public partial class _1ActorandInfoActortablenamefixed2Infoactorcolumnnamefixed : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_ActorsActor_Actors_ActorID",
+                table: "ActorsActor");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_ActorsActor_Info_InfoID",
+                table: "ActorsActor");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_ActorsActor",
+                table: "ActorsActor");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_Actors",
+                table: "Actors");
+
+            migrationBuilder.DropColumn(
+                name: "Justification",
+                table: "ActorsActor");
+
+            migrationBuilder.RenameTable(
+                name: "ActorsActor",
+                newName: "info_actor");
+
+            migrationBuilder.RenameTable(
+                name: "Actors",
+                newName: "actor");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_ActorsActor_InfoID",
+                table: "info_actor",
+                newName: "IX_info_actor_InfoID");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_ActorsActor_ActorID",
+                table: "info_actor",
+                newName: "IX_info_actor_ActorID");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "SequenceDiagram",
+                table: "ThreatDiagram",
+                type: "longtext",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "InfoID",
+                table: "ThreatDiagram",
+                type: "char(36)",
+                nullable: false,
+                collation: "ascii_general_ci",
+                oldClrType: typeof(Guid),
+                oldType: "uniqueidentifier(36)")
+                .OldAnnotation("Relational:Collation", "ascii_general_ci");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FlowDiagram",
+                table: "ThreatDiagram",
+                type: "longtext",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "ID",
+                table: "ThreatDiagram",
+                type: "char(36)",
+                nullable: false,
+                collation: "ascii_general_ci",
+                oldClrType: typeof(Guid),
+                oldType: "uniqueidentifier(36)")
+                .OldAnnotation("Relational:Collation", "ascii_general_ci");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedOn",
+                table: "Threat",
+                type: "datetime(6)",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2(6)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ThreatTitle",
+                table: "Threat",
+                type: "longtext",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ThreatDescription",
+                table: "Threat",
+                type: "longtext",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "ThreatDate",
+                table: "Threat",
+                type: "datetime(6)",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2(6)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Status",
+                table: "Threat",
+                type: "varchar(50)",
+                maxLength: 50,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(50)",
+                oldMaxLength: 50,
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "ScanID",
+                table: "Threat",
+                type: "char(36)",
+                nullable: true,
+                collation: "ascii_general_ci",
+                oldClrType: typeof(Guid),
+                oldType: "uniqueidentifier(36)",
+                oldNullable: true)
+                .OldAnnotation("Relational:Collation", "ascii_general_ci");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "ScanDate",
+                table: "Threat",
+                type: "datetime(6)",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2(6)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Risk",
+                table: "Threat",
+                type: "varchar(20)",
+                maxLength: 20,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(20)",
+                oldMaxLength: 20,
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Remediation",
+                table: "Threat",
+                type: "longtext",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "Threat",
+                type: "varchar(100)",
+                maxLength: 100,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(100)",
+                oldMaxLength: 100)
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Justification",
+                table: "Threat",
+                type: "longtext",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<bool>(
+                name: "IsUpdated",
+                table: "Threat",
+                type: "tinyint(1)",
+                nullable: true,
+                oldClrType: typeof(ulong),
+                oldType: "bit",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<bool>(
+                name: "IsDeleted",
+                table: "Threat",
+                type: "tinyint(1)",
+                nullable: true,
+                oldClrType: typeof(ulong),
+                oldType: "bit",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "InfoID",
+                table: "Threat",
+                type: "char(36)",
+                nullable: false,
+                collation: "ascii_general_ci",
+                oldClrType: typeof(Guid),
+                oldType: "uniqueidentifier(36)")
+                .OldAnnotation("Relational:Collation", "ascii_general_ci");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "DeletedOn",
+                table: "Threat",
+                type: "datetime(6)",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2(6)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Categories",
+                table: "Threat",
+                type: "longtext",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "ID",
+                table: "Threat",
+                type: "char(36)",
+                nullable: false,
+                collation: "ascii_general_ci",
+                oldClrType: typeof(Guid),
+                oldType: "uniqueidentifier(36)")
+                .OldAnnotation("Relational:Collation", "ascii_general_ci");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedOn",
+                table: "Info",
+                type: "datetime(6)",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2(6)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Status",
+                table: "Info",
+                type: "varchar(50)",
+                maxLength: 50,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(50)",
+                oldMaxLength: 50)
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "ScanDate",
+                table: "Info",
+                type: "datetime(6)",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2(6)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "RepoName",
+                table: "Info",
+                type: "varchar(200)",
+                maxLength: 200,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(200)",
+                oldMaxLength: 200)
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "Info",
+                type: "varchar(200)",
+                maxLength: 200,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(200)",
+                oldMaxLength: 200)
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<bool>(
+                name: "IsUpdated",
+                table: "Info",
+                type: "tinyint(1)",
+                nullable: true,
+                oldClrType: typeof(ulong),
+                oldType: "bit",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<bool>(
+                name: "IsDeleted",
+                table: "Info",
+                type: "tinyint(1)",
+                nullable: true,
+                oldClrType: typeof(ulong),
+                oldType: "bit",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "DeletedOn",
+                table: "Info",
+                type: "datetime(6)",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2(6)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "ID",
+                table: "Info",
+                type: "char(36)",
+                nullable: false,
+                collation: "ascii_general_ci",
+                oldClrType: typeof(Guid),
+                oldType: "uniqueidentifier(36)")
+                .OldAnnotation("Relational:Collation", "ascii_general_ci");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedOn",
+                table: "info_actor",
+                type: "datetime(6)",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2(6)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<bool>(
+                name: "IsUpdated",
+                table: "info_actor",
+                type: "tinyint(1)",
+                nullable: true,
+                oldClrType: typeof(ulong),
+                oldType: "bit",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "InfoID",
+                table: "info_actor",
+                type: "char(36)",
+                nullable: false,
+                collation: "ascii_general_ci",
+                oldClrType: typeof(Guid),
+                oldType: "uniqueidentifier(36)")
+                .OldAnnotation("Relational:Collation", "ascii_general_ci");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "ActorID",
+                table: "info_actor",
+                type: "char(36)",
+                nullable: false,
+                collation: "ascii_general_ci",
+                oldClrType: typeof(Guid),
+                oldType: "uniqueidentifier(36)")
+                .OldAnnotation("Relational:Collation", "ascii_general_ci");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "ID",
+                table: "info_actor",
+                type: "char(36)",
+                nullable: false,
+                collation: "ascii_general_ci",
+                oldClrType: typeof(Guid),
+                oldType: "uniqueidentifier(36)")
+                .OldAnnotation("Relational:Collation", "ascii_general_ci");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Comment",
+                table: "info_actor",
+                type: "longtext",
+                nullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedOn",
+                table: "actor",
+                type: "datetime(6)",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2(6)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Type",
+                table: "actor",
+                type: "varchar(50)",
+                maxLength: 50,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(50)",
+                oldMaxLength: 50,
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Status",
+                table: "actor",
+                type: "varchar(50)",
+                maxLength: 50,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(50)",
+                oldMaxLength: 50,
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "actor",
+                type: "varchar(200)",
+                maxLength: 200,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(200)",
+                oldMaxLength: 200)
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Email",
+                table: "actor",
+                type: "varchar(200)",
+                maxLength: 200,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(200)",
+                oldMaxLength: 200)
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Description",
+                table: "actor",
+                type: "varchar(200)",
+                maxLength: 200,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(200)",
+                oldMaxLength: 200,
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "AddedOn",
+                table: "actor",
+                type: "datetime(6)",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2(6)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "ID",
+                table: "actor",
+                type: "char(36)",
+                nullable: false,
+                collation: "ascii_general_ci",
+                oldClrType: typeof(Guid),
+                oldType: "uniqueidentifier(36)")
+                .OldAnnotation("Relational:Collation", "ascii_general_ci");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_info_actor",
+                table: "info_actor",
+                column: "ID");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_actor",
+                table: "actor",
+                column: "ID");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_info_actor_Info_InfoID",
+                table: "info_actor",
+                column: "InfoID",
+                principalTable: "Info",
+                principalColumn: "ID",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_info_actor_actor_ActorID",
+                table: "info_actor",
+                column: "ActorID",
+                principalTable: "actor",
+                principalColumn: "ID",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_info_actor_Info_InfoID",
+                table: "info_actor");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_info_actor_actor_ActorID",
+                table: "info_actor");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_info_actor",
+                table: "info_actor");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_actor",
+                table: "actor");
+
+            migrationBuilder.DropColumn(
+                name: "Comment",
+                table: "info_actor");
+
+            migrationBuilder.RenameTable(
+                name: "info_actor",
+                newName: "ActorsActor");
+
+            migrationBuilder.RenameTable(
+                name: "actor",
+                newName: "Actors");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_info_actor_InfoID",
+                table: "ActorsActor",
+                newName: "IX_ActorsActor_InfoID");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_info_actor_ActorID",
+                table: "ActorsActor",
+                newName: "IX_ActorsActor_ActorID");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "SequenceDiagram",
+                table: "ThreatDiagram",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "longtext",
+                oldNullable: true)
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "InfoID",
+                table: "ThreatDiagram",
+                type: "uniqueidentifier(36)",
+                nullable: false,
+                collation: "ascii_general_ci",
+                oldClrType: typeof(Guid),
+                oldType: "char(36)")
+                .OldAnnotation("Relational:Collation", "ascii_general_ci");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FlowDiagram",
+                table: "ThreatDiagram",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "longtext",
+                oldNullable: true)
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "ID",
+                table: "ThreatDiagram",
+                type: "uniqueidentifier(36)",
+                nullable: false,
+                collation: "ascii_general_ci",
+                oldClrType: typeof(Guid),
+                oldType: "char(36)")
+                .OldAnnotation("Relational:Collation", "ascii_general_ci");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedOn",
+                table: "Threat",
+                type: "datetime2(6)",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime(6)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ThreatTitle",
+                table: "Threat",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "longtext",
+                oldNullable: true)
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ThreatDescription",
+                table: "Threat",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "longtext",
+                oldNullable: true)
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "ThreatDate",
+                table: "Threat",
+                type: "datetime2(6)",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime(6)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Status",
+                table: "Threat",
+                type: "nvarchar(50)",
+                maxLength: 50,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(50)",
+                oldMaxLength: 50,
+                oldNullable: true)
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "ScanID",
+                table: "Threat",
+                type: "uniqueidentifier(36)",
+                nullable: true,
+                collation: "ascii_general_ci",
+                oldClrType: typeof(Guid),
+                oldType: "char(36)",
+                oldNullable: true)
+                .OldAnnotation("Relational:Collation", "ascii_general_ci");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "ScanDate",
+                table: "Threat",
+                type: "datetime2(6)",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime(6)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Risk",
+                table: "Threat",
+                type: "nvarchar(20)",
+                maxLength: 20,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(20)",
+                oldMaxLength: 20,
+                oldNullable: true)
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Remediation",
+                table: "Threat",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "longtext",
+                oldNullable: true)
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "Threat",
+                type: "nvarchar(100)",
+                maxLength: 100,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "varchar(100)",
+                oldMaxLength: 100)
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Justification",
+                table: "Threat",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "longtext",
+                oldNullable: true)
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<ulong>(
+                name: "IsUpdated",
+                table: "Threat",
+                type: "bit",
+                nullable: true,
+                oldClrType: typeof(bool),
+                oldType: "tinyint(1)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<ulong>(
+                name: "IsDeleted",
+                table: "Threat",
+                type: "bit",
+                nullable: true,
+                oldClrType: typeof(bool),
+                oldType: "tinyint(1)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "InfoID",
+                table: "Threat",
+                type: "uniqueidentifier(36)",
+                nullable: false,
+                collation: "ascii_general_ci",
+                oldClrType: typeof(Guid),
+                oldType: "char(36)")
+                .OldAnnotation("Relational:Collation", "ascii_general_ci");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "DeletedOn",
+                table: "Threat",
+                type: "datetime2(6)",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime(6)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Categories",
+                table: "Threat",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "longtext",
+                oldNullable: true)
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "ID",
+                table: "Threat",
+                type: "uniqueidentifier(36)",
+                nullable: false,
+                collation: "ascii_general_ci",
+                oldClrType: typeof(Guid),
+                oldType: "char(36)")
+                .OldAnnotation("Relational:Collation", "ascii_general_ci");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedOn",
+                table: "Info",
+                type: "datetime2(6)",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime(6)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Status",
+                table: "Info",
+                type: "nvarchar(50)",
+                maxLength: 50,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "varchar(50)",
+                oldMaxLength: 50)
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "ScanDate",
+                table: "Info",
+                type: "datetime2(6)",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime(6)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "RepoName",
+                table: "Info",
+                type: "nvarchar(200)",
+                maxLength: 200,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "varchar(200)",
+                oldMaxLength: 200)
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "Info",
+                type: "nvarchar(200)",
+                maxLength: 200,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "varchar(200)",
+                oldMaxLength: 200)
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<ulong>(
+                name: "IsUpdated",
+                table: "Info",
+                type: "bit",
+                nullable: true,
+                oldClrType: typeof(bool),
+                oldType: "tinyint(1)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<ulong>(
+                name: "IsDeleted",
+                table: "Info",
+                type: "bit",
+                nullable: true,
+                oldClrType: typeof(bool),
+                oldType: "tinyint(1)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "DeletedOn",
+                table: "Info",
+                type: "datetime2(6)",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime(6)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "ID",
+                table: "Info",
+                type: "uniqueidentifier(36)",
+                nullable: false,
+                collation: "ascii_general_ci",
+                oldClrType: typeof(Guid),
+                oldType: "char(36)")
+                .OldAnnotation("Relational:Collation", "ascii_general_ci");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedOn",
+                table: "ActorsActor",
+                type: "datetime2(6)",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime(6)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<ulong>(
+                name: "IsUpdated",
+                table: "ActorsActor",
+                type: "bit",
+                nullable: true,
+                oldClrType: typeof(bool),
+                oldType: "tinyint(1)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "InfoID",
+                table: "ActorsActor",
+                type: "uniqueidentifier(36)",
+                nullable: false,
+                collation: "ascii_general_ci",
+                oldClrType: typeof(Guid),
+                oldType: "char(36)")
+                .OldAnnotation("Relational:Collation", "ascii_general_ci");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "ActorID",
+                table: "ActorsActor",
+                type: "uniqueidentifier(36)",
+                nullable: false,
+                collation: "ascii_general_ci",
+                oldClrType: typeof(Guid),
+                oldType: "char(36)")
+                .OldAnnotation("Relational:Collation", "ascii_general_ci");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "ID",
+                table: "ActorsActor",
+                type: "uniqueidentifier(36)",
+                nullable: false,
+                collation: "ascii_general_ci",
+                oldClrType: typeof(Guid),
+                oldType: "char(36)")
+                .OldAnnotation("Relational:Collation", "ascii_general_ci");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Justification",
+                table: "ActorsActor",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedOn",
+                table: "Actors",
+                type: "datetime2(6)",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime(6)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Type",
+                table: "Actors",
+                type: "nvarchar(50)",
+                maxLength: 50,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(50)",
+                oldMaxLength: 50,
+                oldNullable: true)
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Status",
+                table: "Actors",
+                type: "nvarchar(50)",
+                maxLength: 50,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(50)",
+                oldMaxLength: 50,
+                oldNullable: true)
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "Actors",
+                type: "nvarchar(200)",
+                maxLength: 200,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "varchar(200)",
+                oldMaxLength: 200)
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Email",
+                table: "Actors",
+                type: "nvarchar(200)",
+                maxLength: 200,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "varchar(200)",
+                oldMaxLength: 200)
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Description",
+                table: "Actors",
+                type: "nvarchar(200)",
+                maxLength: 200,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(200)",
+                oldMaxLength: 200,
+                oldNullable: true)
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "AddedOn",
+                table: "Actors",
+                type: "datetime2(6)",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime(6)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "ID",
+                table: "Actors",
+                type: "uniqueidentifier(36)",
+                nullable: false,
+                collation: "ascii_general_ci",
+                oldClrType: typeof(Guid),
+                oldType: "char(36)")
+                .OldAnnotation("Relational:Collation", "ascii_general_ci");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_ActorsActor",
+                table: "ActorsActor",
+                column: "ID");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_Actors",
+                table: "Actors",
+                column: "ID");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ActorsActor_Actors_ActorID",
+                table: "ActorsActor",
+                column: "ActorID",
+                principalTable: "Actors",
+                principalColumn: "ID",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ActorsActor_Info_InfoID",
+                table: "ActorsActor",
+                column: "InfoID",
+                principalTable: "Info",
+                principalColumn: "ID",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/Models/Actor.cs
+++ b/Models/Actor.cs
@@ -3,7 +3,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Jovian_Project_Backend.Models
 {
-
+    [Table("actor")]
 public class Actor
     {
         [Key]

--- a/Models/InfoActor.cs
+++ b/Models/InfoActor.cs
@@ -3,6 +3,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Jovian_Project_Backend.Models
 {
+    [Table("info_actor")]
     public class InfoActor
     {
         [Key]
@@ -17,7 +18,7 @@ namespace Jovian_Project_Backend.Models
         public bool? IsUpdated { get; set; }
         public DateTime? UpdatedOn { get; set; }
 
-        public string? Justification { get; set; }
+        public string? Comment { get; set; }
 
         // Navigation properties
         [ForeignKey(nameof(InfoID))]


### PR DESCRIPTION
This commit updates the database schema and entity models to support a migration from SQL Server to MySQL. Key changes include:

- Updated `ApplicationDbContextModelSnapshot.cs` to reflect MySQL-compatible schema changes.
  - Changed max identifier length to 64.
  - Switched database provider to MySQL (`MySqlModelBuilderExtensions.AutoIncrementColumns`).
  - Renamed tables (`Actor` to `actor`, `InfoActor` to `info_actor`) and updated column types for MySQL compatibility.
  - Added a new `Comment` column to the `info_actor` table, replacing the `Justification` column.

- Updated entity models:
  - Mapped `Actor` and `InfoActor` classes to their respective renamed tables using `[Table]` attributes.
  - Replaced `Justification` property with `Comment` in `InfoActor`.

- Introduced a new migration file `20250523092951_1 Actor and InfoActor table name fixed 2 Info actor column name fixed` to apply these schema changes.

These updates ensure compatibility with MySQL, improve naming consistency, and enhance schema clarity.